### PR TITLE
fix(browser): allow return null from beforeSend

### DIFF
--- a/libs/browser/src/lib/models/browser-sentry-client-options.ts
+++ b/libs/browser/src/lib/models/browser-sentry-client-options.ts
@@ -7,7 +7,7 @@ import { MicroSentryPluginConstructor } from './plugin';
 
 export interface BrowserSentryClientOptions extends SentryClientOptions {
   plugins?: MicroSentryPluginConstructor[];
-  beforeSend?(request: SentryRequestBody): SentryRequestBody;
+  beforeSend?(request: SentryRequestBody): SentryRequestBody | null;
   beforeBreadcrumb?(breadcrumb: Breadcrumb): Breadcrumb;
   ignoreErrors?: Array<string | RegExp>;
   blacklistUrls?: Array<string | RegExp>;

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
@@ -245,43 +245,38 @@ describe('BrowserMicroSentryClient', () => {
 
   describe('beforeSend', () => {
     let sendSpy: jest.SpyInstance;
+    let beforeSendClient: BrowserMicroSentryClient;
 
     beforeAll(() => {
-      sendSpy = jest.spyOn(
-        // смотрим за супер Methodом, что бы отлавливать мутации в Methodе дочернего класса
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (client.constructor as any).__proto__.prototype,
-        'send'
-      );
-
-      client = new BrowserMicroSentryClient({
+      beforeSendClient = new BrowserMicroSentryClient({
         dsn: 'http://secret@exampl.dsn/2',
         release: '1.0.0',
         beforeSend: () => null,
       });
+
+      sendSpy = jest.spyOn(
+        // смотрим за супер Methodом, что бы отлавливать мутации в Methodе дочернего класса
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (beforeSendClient.constructor as any).__proto__.prototype,
+        'send'
+      );
     });
 
     it('Should not send data if beforeSend returns null', () => {
-      client.report({ message: 'Error', name: 'Error', stack: '' });
+      beforeSendClient.report({ message: 'Error', name: 'Error', stack: '' });
 
       expect(sendSpy).not.toHaveBeenCalled();
     });
 
     it('Should not clean breadcrumbs if beforeSend returns null', () => {
-      client = new BrowserMicroSentryClient({
-        dsn: 'http://secret@exampl.dsn/2',
-        release: '1.0.0',
-        beforeSend: () => null,
-      });
-
-      client.addBreadcrumb({
+      beforeSendClient.addBreadcrumb({
         event_id: 'id',
         type: 'console',
         level: Severity.critical,
       });
-      client.report({ message: 'Error', name: 'Error', stack: '' });
+      beforeSendClient.report({ message: 'Error', name: 'Error', stack: '' });
 
-      expect(client.state.breadcrumbs?.length).toBe(1);
+      expect(beforeSendClient.state.breadcrumbs?.length).toBe(1);
     });
   });
 

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.ts
@@ -186,7 +186,16 @@ export class BrowserMicroSentryClient extends MicroSentryClient {
       return;
     }
 
-    super.send(this.beforeSend({ release: this.release, ...request }));
+    const beforeSendResult = this.beforeSend({
+      release: this.release,
+      ...request,
+    });
+
+    if (!beforeSendResult) {
+      return;
+    }
+
+    super.send(beforeSendResult);
 
     this.setBreadcrumbs(undefined);
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

beforeSend does not allow return of null to stop error processing

Closes #19 

## What is the new behavior?

Allow to beforeSend to return null

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
