### PR TITLE
fix: allow null in setUser method

### DIFF
--- a/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
@@ -160,6 +160,14 @@ describe('BrowserMicroSentryClient', () => {
       });
     });
 
+    it('Should clear user on setUser(null)', () => {
+      client.setUser({ username: 'test' });
+
+      client.setUser(null);
+
+      expect(client.state.user).toBeUndefined();
+    });
+
     afterEach(() => {
       client.clearState();
     });

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.ts
@@ -90,8 +90,8 @@ export class BrowserMicroSentryClient extends MicroSentryClient {
     return this;
   }
 
-  setUser(user: User): this {
-    this.setKeyState('user', { ...user });
+  setUser(user: User | null): this {
+    this.setKeyState('user', user ? { ...user } : undefined);
 
     return this;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

Allow setUser to accept null

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

There is no easy way to clear user

Closes #21 

## What is the new behavior?

setUser with null would allow to clear user

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
