### PR TITLE
fix: allow null in beforeBreadcrumb method #23

### DIFF
--- a/libs/browser/src/lib/models/browser-sentry-client-options.ts
+++ b/libs/browser/src/lib/models/browser-sentry-client-options.ts
@@ -8,7 +8,7 @@ import { MicroSentryPluginConstructor } from './plugin';
 export interface BrowserSentryClientOptions extends SentryClientOptions {
   plugins?: MicroSentryPluginConstructor[];
   beforeSend?(request: SentryRequestBody): SentryRequestBody | null;
-  beforeBreadcrumb?(breadcrumb: Breadcrumb): Breadcrumb;
+  beforeBreadcrumb?(breadcrumb: Breadcrumb): Breadcrumb | null;
   ignoreErrors?: Array<string | RegExp>;
   blacklistUrls?: Array<string | RegExp>;
   release?: string;

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.spec.ts
@@ -205,6 +205,38 @@ describe('BrowserMicroSentryClient', () => {
       });
     });
 
+    it('should skip breadcrumbs if beforeBreadcrumb returns null', () => {
+      client = new BrowserMicroSentryClient({
+        dsn: 'http://secret@exampl.dsn/2',
+        release: '1.0.0',
+        beforeBreadcrumb: (breadcrumb) =>
+          breadcrumb.level === Severity.debug ? null : breadcrumb,
+      });
+
+      // NOTE: breadcrump to be ignored
+      client.addBreadcrumb({
+        event_id: 'id1',
+        type: 'console',
+        level: Severity.debug,
+      });
+
+      // NOTE: breadcrump to be added
+      client.addBreadcrumb({
+        event_id: 'id2',
+        type: 'console',
+        level: Severity.critical,
+      });
+
+      expect(client.state.breadcrumbs).toEqual([
+        {
+          event_id: 'id2',
+          type: 'console',
+          level: 'critical',
+          timestamp: expect.any(Number),
+        },
+      ]);
+    });
+
     afterAll(() => {
       client.clearState();
     });

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.ts
@@ -117,12 +117,18 @@ export class BrowserMicroSentryClient extends MicroSentryClient {
     this.setBreadcrumbs(undefined);
   }
 
-  addBreadcrumb(breadcrumb: Breadcrumb) {
+  addBreadcrumb(breadcrumb: Breadcrumb): void {
+    const result = this.beforeBreadcrumb(breadcrumb);
+
+    if (!result) {
+      return;
+    }
+
     this.extendState({
       breadcrumbs: [
         {
           timestamp: Date.now() / 1_000,
-          ...this.beforeBreadcrumb(breadcrumb),
+          ...result,
         },
       ],
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

if `beforeBreadcrumb` return null it would not prevent it from logging into breadcrumbs

Closes #23 

## What is the new behavior?

you could return null from `beforeBreadcrumb` to ignore breadcrumb item

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
