### PR TITLE
fix: add max breadcrumbs limitation

### DIFF
--- a/libs/browser/src/lib/consts/max-breadcrumbs.ts
+++ b/libs/browser/src/lib/consts/max-breadcrumbs.ts
@@ -1,0 +1,1 @@
+export const MAX_BREADCRUMBS = 100;

--- a/libs/browser/src/lib/models/browser-sentry-client-options.ts
+++ b/libs/browser/src/lib/models/browser-sentry-client-options.ts
@@ -12,4 +12,5 @@ export interface BrowserSentryClientOptions extends SentryClientOptions {
   ignoreErrors?: Array<string | RegExp>;
   blacklistUrls?: Array<string | RegExp>;
   release?: string;
+  maxBreadcrumbs?: number;
 }

--- a/libs/browser/src/lib/services/browser-micro-sentry-client.ts
+++ b/libs/browser/src/lib/services/browser-micro-sentry-client.ts
@@ -140,18 +140,12 @@ export class BrowserMicroSentryClient extends MicroSentryClient {
       ],
     });
 
-    const breadcrumbs = this.getKeyState(this.breadcrumbsKeyName);
-
-    if (!!breadcrumbs && (breadcrumbs.length ?? 0) > this.maxBreadcrumbs) {
-      this.setKeyState(
-        this.breadcrumbsKeyName,
-        this.maxBreadcrumbs > 0 ? breadcrumbs.slice(-this.maxBreadcrumbs) : []
-      );
-    }
+    this.trimBreadcrumbs();
   }
 
   setBreadcrumbs(breadcrumbs: Breadcrumb[] | undefined) {
-    this.setKeyState('breadcrumbs', breadcrumbs);
+    this.setKeyState(this.breadcrumbsKeyName, breadcrumbs);
+    this.trimBreadcrumbs();
   }
 
   captureMessage(message: string, level?: Severity) {
@@ -325,5 +319,15 @@ export class BrowserMicroSentryClient extends MicroSentryClient {
 
   private getKeyState<T extends keyof State>(key: T): State[T] {
     return this._state[key];
+  }
+
+  private trimBreadcrumbs(): void {
+    const breadcrumbs = this.getKeyState(this.breadcrumbsKeyName);
+    if (breadcrumbs && (breadcrumbs.length ?? 0) > this.maxBreadcrumbs) {
+      this.setKeyState(
+        this.breadcrumbsKeyName,
+        this.maxBreadcrumbs > 0 ? breadcrumbs.slice(-this.maxBreadcrumbs) : []
+      );
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

## What is the current behavior?

Adds max breadcrumbs limitation

Closes #

## What is the new behavior?

It's possible to set maxBreadcrumbs limitation, if not set, the value of 100 is used

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Limitation of 100 breadcrumbs is applied by default